### PR TITLE
v4.0.3

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,5 @@
 approvedGitRepositories:
-  - "**"
+  - '**'
 
 enableScripts: true
 

--- a/README.md
+++ b/README.md
@@ -139,3 +139,17 @@ See [HELP.md](./companion/HELP.md) and [LICENSE](./LICENSE)
 - Correct description of `Crosspoint Connected on specific level` feedback
 - P-Queue updated to `9.2.0`
 - Typescript-eslint updated to `8.59.1`
+
+### Version 4.0.3
+
+Fix: `destination source name` feedback source offset by 1
+Improve: Handling of levels and matrix values in extended mode (> 16).
+Fix: `destinations` variable `name` field
+Fix: Don't return `SetCrosspoint` early after logging message to say proceeding with extended command despite extended commands not being enabled
+Improvement: Prefer extended command set whenever it is supported
+Improvement: Don't overwrite config in `configUpdated()`
+Improvement: Wait for `ACK` during `sendMessage`, queue processing and consecutive actions will progress after `ACK`
+Improvement: Refactor `updateAllCrosspoints()` for better efficieny
+Improvement: check for changed size of `coreVariables` during `updateVariableDefinitions()`
+Improvement: clear `this.ackCallbacks` on socket `end` event
+Improvement: Other minor refactors / typing improvements

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
 		"@types/node": "^22.19.17",
 		"eslint": "^9.39.4",
 		"husky": "^9.1.7",
-		"lint-staged": "^16.4.0",
+		"lint-staged": "^17.0.2",
 		"prettier": "^3.8.3",
 		"rimraf": "^6.1.3",
 		"typescript": "^6.0.3",
-		"typescript-eslint": "^8.59.1"
+		"typescript-eslint": "^8.59.2"
 	},
 	"engines": {
-		"node": "^22.20"
+		"node": "^22.22.1"
 	},
 	"prettier": "@companion-module/tools/.prettierrc.json",
 	"packageManager": "yarn@4.14.1",

--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
 	"devDependencies": {
 		"@companion-module/tools": "^3.0.1",
 		"@types/lodash": "^4.17.24",
-		"@types/node": "^22.19.17",
+		"@types/node": "^22.19.19",
 		"eslint": "^9.39.4",
 		"husky": "^9.1.7",
-		"lint-staged": "^17.0.2",
+		"lint-staged": "^17.0.4",
 		"prettier": "^3.8.3",
 		"rimraf": "^6.1.3",
 		"typescript": "^6.0.3",
-		"typescript-eslint": "^8.59.2"
+		"typescript-eslint": "^8.59.3"
 	},
 	"engines": {
 		"node": "^22.22.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generic-swp08",
-	"version": "4.0.2",
+	"version": "4.0.3",
 	"main": "dist/index.js",
 	"type": "module",
 	"scripts": {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -68,7 +68,8 @@ export type ActionSchema = {
 		}
 	}
 	[ActionIds.Take]: {
-		options: Record<string, never>
+		// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+		options: {}
 	}
 	[ActionIds.Clear]: {
 		options: {
@@ -91,7 +92,8 @@ export type ActionSchema = {
 		}
 	}
 	[ActionIds.GetNames]: {
-		options: Record<string, never>
+		// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+		options: {}
 	}
 }
 

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -68,8 +68,7 @@ export type ActionSchema = {
 		}
 	}
 	[ActionIds.Take]: {
-		// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-		options: {}
+		options: Record<string, never>
 	}
 	[ActionIds.Clear]: {
 		options: {
@@ -92,8 +91,7 @@ export type ActionSchema = {
 		}
 	}
 	[ActionIds.GetNames]: {
-		// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-		options: {}
+		options: Record<string, never>
 	}
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,6 +52,7 @@ export function GetConfigFields(): SomeCompanionConfigField[] {
 			range: true,
 			step: 1,
 			isVisibleExpression: '!$(options:extended_support)',
+			asInteger: true,
 		},
 		{
 			type: 'number',
@@ -64,6 +65,7 @@ export function GetConfigFields(): SomeCompanionConfigField[] {
 			range: true,
 			step: 1,
 			isVisibleExpression: '$(options:extended_support)',
+			asInteger: true,
 		},
 		{
 			type: 'number',
@@ -76,6 +78,7 @@ export function GetConfigFields(): SomeCompanionConfigField[] {
 			range: true,
 			step: 1,
 			isVisibleExpression: '!$(options:extended_support)',
+			asInteger: true,
 		},
 		{
 			type: 'number',
@@ -88,6 +91,7 @@ export function GetConfigFields(): SomeCompanionConfigField[] {
 			range: true,
 			step: 1,
 			isVisibleExpression: '$(options:extended_support)',
+			asInteger: true,
 		},
 		{
 			type: 'checkbox',
@@ -142,6 +146,7 @@ export function GetConfigFields(): SomeCompanionConfigField[] {
 				{ id: '01', label: '8 characters' },
 				{ id: '02', label: '12 characters' },
 			],
+			allowCustom: false,
 		},
 	]
 }

--- a/src/feedbacks.ts
+++ b/src/feedbacks.ts
@@ -79,7 +79,8 @@ export type FeedbackSchema = {
 	}
 	[FeedbackIds.CanTake]: {
 		type: 'boolean'
-		options: Record<string, never>
+		// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+		options: {}
 	}
 }
 

--- a/src/feedbacks.ts
+++ b/src/feedbacks.ts
@@ -311,7 +311,7 @@ export function UpdateFeedbacks(self: SW_P_08): void {
 			// look for self dest in route table
 			logger.debug(`${FeedbackIds.DestinationSourceName} feedback ${feedback.options.dest}:${feedback.options.level}`)
 			const source = self.getRoutemapEntries(dest)[level]
-			return self.source_names.get(source)?.label ?? ''
+			return self.source_names.get(source - 1)?.label ?? ''
 		},
 	}
 

--- a/src/feedbacks.ts
+++ b/src/feedbacks.ts
@@ -79,8 +79,7 @@ export type FeedbackSchema = {
 	}
 	[FeedbackIds.CanTake]: {
 		type: 'boolean'
-		// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-		options: {}
+		options: Record<string, never>
 	}
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,9 +142,9 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 	}
 
 	public addFeedbacksToCheck(...feedbacks: FeedbackIds[]): void {
-		feedbacks.forEach((fb) => {
+		for (const fb of feedbacks) {
 			this.feedbacksToCheck.add(fb)
-		})
+		}
 		this.throttledFeedbackCheck()
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -222,10 +222,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 			return true
 		}
 
-		if (this.commands.indexOf(cmdCode) !== -1) {
-			return true
-		}
-		return false
+		return this.commands.includes(cmdCode)
 	}
 
 	/**
@@ -246,7 +243,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 				this.config.supported_commands_on_connect === true &&
 				this.commands.length > 0
 			) {
-				if (this.commands.indexOf(cmdCode) === -1) {
+				if (!this.hasCommand(cmdCode)) {
 					this.log('warn', `Command code ${cmdCode} is not implemented by this hardware`)
 					return
 				}

--- a/src/index.ts
+++ b/src/index.ts
@@ -753,7 +753,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 			return
 		}
 
-		if (Number.isNaN(levelN) || levelN < 0 || levelN > 256) {
+		if (Number.isNaN(levelN) || levelN < 1 || levelN > 256) {
 			this.log('warn', `Unable to route level ${levelN}`)
 			return
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -558,48 +558,47 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 
 	private updateAllCrosspoints(): void {
 		const variables = new Map()
-		const numDests = this.dest_names.size > 0 ? this.dest_names.size : 256
-		for (let dest = 1; dest <= numDests; dest++) {
-			if (dest === this.selected_dest) {
-				const map = this.routeMap.get(dest) ?? new Map()
-				for (let level = 1; level <= this.config.max_levels; level++) {
-					if (map.has(level)) {
-						const source = map.get(level)
-						variables.set(`Sel_Dest_Source_Level_${level}`, source)
-						if (this.source_names.size > 0) {
-							// only if names have been retrieved
-							try {
-								variables.set(
-									`Sel_Dest_Source_Name_Level_${level}`,
-									stripNumber(this.source_names.get(source - 1)?.label || 'N/A'),
-								)
-							} catch (e: any) {
-								this.log(
-									'debug',
-									`Unable to set Sel_Dest_Source_Name_Level ${e instanceof Error ? e.message : e.toString()}`,
-								)
-							}
+
+		if (this.selected_dest) {
+			const map = this.routeMap.get(this.selected_dest) ?? new Map<number, number>()
+			const hasSourceNames = this.source_names.size > 0
+
+			for (let level = 1; level <= this.effectiveLevels; level++) {
+				if (map.has(level)) {
+					const source = map.get(level) ?? 0
+					variables.set(`Sel_Dest_Source_Level_${level}`, source)
+
+					// Hoist the source_names check outside the level loop
+					if (hasSourceNames) {
+						try {
+							variables.set(
+								`Sel_Dest_Source_Name_Level_${level}`,
+								stripNumber(this.source_names.get(source - 1)?.label || 'N/A'),
+							)
+						} catch (e: any) {
+							this.log(
+								'debug',
+								`Unable to set Sel_Dest_Source_Name_Level ${e instanceof Error ? e.message : e.toString()}`,
+							)
 						}
-					} else {
-						variables.set(`Sel_Dest_Source_Level_${level}`, -1)
-						variables.set(`Sel_Dest_Source_Name_Level_${level}`, 'N/A')
 					}
+				} else {
+					variables.set(`Sel_Dest_Source_Level_${level}`, -1)
+					variables.set(`Sel_Dest_Source_Name_Level_${level}`, 'N/A')
 				}
 			}
 		}
 
 		if (this.config.tally_dump_variables) {
-			for (const index of this.routeMap.keys()) {
-				const levels = this.routeMap.get(index) ?? new Map()
-				for (const level of levels.keys()) {
-					variables.set(getRouteVariableName(level, index), levels.get(level))
+			for (const [index, levels] of this.routeMap) {
+				for (const [level, source] of levels) {
+					variables.set(getRouteVariableName(level, index), source)
 				}
 			}
 		}
 
 		this.setVariableValuesCached(Object.fromEntries(variables))
 
-		// TODO: separate id for each destination, and only send source_dest_route if any of them have changed
 		this.addFeedbacksToCheck(
 			FeedbackIds.SourceDestRoute,
 			FeedbackIds.CrosspointConnected,

--- a/src/index.ts
+++ b/src/index.ts
@@ -903,28 +903,23 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 				let packetIndex = 0
 				let crc = 0
 
-				// Remove DLE escaping and calculate checksum
-				// Start at 2 to skip SOM
+				// Remove DLE escaping
 				for (let k = 2; k < j; k++) {
 					if (data[k] === DLE && data[k + 1] === DLE) {
-						// We found a double DLE, replace it with a single DLE
 						k++
 						packet[packetIndex++] = DLE
-						if (k < j - 1) {
-							crc += data[k]
-						}
 						continue
 					}
 					packet[packetIndex++] = data[k]
-
-					// add only DATA + BTC to CRC
-					if (k < j - 1) {
-						crc += data[k]
-					}
 				}
 
 				// Trim the packet to the correct size
 				packet = packet.subarray(0, packetIndex)
+
+				// Calculate CRC on the unescaped data: all bytes except CHK (last byte)
+				for (let k = 0; k < packet.length - 1; k++) {
+					crc += packet[k]
+				}
 
 				// Check packet size
 				if (packet[packet.length - 2] !== packet.length - 2) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,7 +241,6 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 			const timeout = setTimeout(() => {
 				const index = this.ackCallbacks.indexOf(entry)
 				if (index !== -1) this.ackCallbacks.splice(index, 1)
-				this.consecutiveAckFailures++
 				reject(new Error('ACK timeout'))
 			}, 1000)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,37 +99,6 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		this.debouncedUpdate.cancel()
 		this.updateStatus(InstanceStatus.Connecting)
 
-		if (config.max_levels === undefined) {
-			config.max_levels = 3
-		}
-		if (config.max_levels_ext === undefined) {
-			config.max_levels_ext = config.max_levels || 3
-		}
-		if (config.extended_support) {
-			const newMatrix = Math.min(config.matrix_ext, 16)
-			const newLevels = Math.min(config.max_levels_ext, 16)
-
-			// Save the clamped values to the normal config too, in case the user
-			// switches between extended and normal mode
-			if (newMatrix !== config.matrix || newLevels !== config.max_levels) {
-				config.matrix = newMatrix
-				config.max_levels = newLevels
-				// This will not trigger a new configUpdated, so continue processing
-				// the rest of the config
-				this.saveConfig(config)
-			}
-		} else {
-			// Keep the extended values updated, in case the user switches
-			// between extended and normal mode
-			if (config.matrix_ext !== config.matrix || config.max_levels_ext !== config.max_levels) {
-				config.matrix_ext = config.matrix
-				config.max_levels_ext = config.max_levels
-				// This will not trigger a new configUpdated, so continue processing
-				// the rest of the config
-				this.saveConfig(config)
-			}
-		}
-
 		this.config = config
 		this.setupVariables()
 		this.updateFeedbacks()

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,43 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		this.throttledFeedbackCheck()
 	}
 
+	/**
+	 * Get maximum configured levels
+	 **/
+
+	private get effectiveLevels(): number {
+		return this.config.extended_support ? this.config.max_levels_ext : this.config.max_levels
+	}
+
+	/**
+	 * Get clamped maximum configured levels for use with non extended mode commands
+	 **/
+
+	private get protocolLevels(): number {
+		return Math.min(this.effectiveLevels, 16)
+	}
+
+	/**
+	 * Get maximum configured matrix
+	 **/
+
+	private get effectiveMatrix(): number {
+		return this.config.extended_support ? this.config.matrix_ext : this.config.matrix
+	}
+
+	/**
+	 * Get  maximum configured matrix for use with non extended mode commands
+	 * @throws if configured matrix exceeds non extended mode range
+	 **/
+
+	private get protocolMatrix(): number {
+		if (!this.config.extended_support && this.effectiveMatrix > 16) {
+			throw new Error('Matrix exceeds protocol limits without extended support')
+		}
+		return this.effectiveMatrix
+	}
+
+
 	// tcp.js functions
 
 	private async sendNak(): Promise<void> {
@@ -207,12 +244,12 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 
 	private async readTally(): Promise<void> {
 		if (this.config.extended_support) {
-			for (let i = 0; i < this.config.max_levels_ext; i++) {
-				await this.sendMessage([cmds.extendedCrosspointTallyDump, this.config.matrix - 1, i])
+			for (let i = 0; i < this.effectiveLevels; i++) {
+				await this.sendMessage([cmds.extendedCrosspointTallyDump, this.effectiveMatrix - 1, i])
 			}
 		} else {
-			for (let i = 0; i < this.config.max_levels; i++) {
-				await this.sendMessage([cmds.crosspointTallyDump, ((this.config.matrix - 1) << 4) | (i & 0x0f)])
+			for (let i = 0; i < this.protocolLevels; i++) {
+				await this.sendMessage([cmds.crosspointTallyDump, ((this.effectiveMatrix - 1) << 4) | (i & 0x0f)])
 			}
 		}
 	}
@@ -360,11 +397,14 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 				while (receivebuffer.length > 0) {
 					// parseData will return the number of bytes consumed, and will retry until no more data is present
 
+					try {
 					const bytesConsumed = this.decode(receivebuffer)
-					if (bytesConsumed === 0) {
-						break
-					}
+						if (bytesConsumed === 0) break
 					receivebuffer = receivebuffer.subarray(bytesConsumed)
+					} catch (e) {
+						this.log('error', `Failed to decode packet: ${e instanceof Error ? e.message : String(e)}`)
+						receivebuffer = receivebuffer.subarray(1) // skip bad byte and keep trying
+					}
 				}
 			})
 		}
@@ -406,7 +446,8 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		const dest = ((data[2] & 0x70) << 3) + data[3] + 1
 		const source = ((data[2] & 0x07) << 7) + data[4] + 1
 
-		if (matrix !== this.config.matrix) {
+		if (matrix !== this.effectiveMatrix) {
+			this.log('warn', `Ignoring matrix ${matrix}, expected ${this.effectiveMatrix}`)
 			return
 		}
 
@@ -421,7 +462,8 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		const dest = ((data[3] << 8) | data[4]) + 1
 		const source = ((data[5] << 8) | data[6]) + 1
 
-		if (matrix !== this.config.matrix) {
+		if (matrix !== this.effectiveMatrix) {
+			this.log('warn', `Ignoring matrix ${matrix}, expected ${this.effectiveMatrix}`)
 			return
 		}
 
@@ -493,7 +535,8 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 	): void {
 		const tallies = data[offset]
 
-		if (matrix !== this.config.matrix) {
+		if (matrix !== this.effectiveMatrix) {
+			this.log('warn', `Ignoring matrix ${matrix}, expected ${this.effectiveMatrix}`)
 			return
 		}
 
@@ -683,7 +726,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 			// Extended command required
 			cmd.push(cmds.extendedCrosspointConnect)
 			// Matrix
-			cmd.push(this.config.matrix - 1)
+			cmd.push(this.effectiveMatrix - 1)
 			// Level
 			cmd.push(level)
 			// Dest DIV 256
@@ -706,7 +749,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 			// Standard Command
 			cmd.push(cmds.crosspointConnect)
 			// Matrix and Level
-			cmd.push(((this.config.matrix - 1) << 4) | (level & 0x0f))
+			cmd.push(((this.protocolMatrix - 1) << 4) | (level & 0x0f))
 			// Multiplier if source or dest > 128
 			cmd.push(
 				((source >> 7) & 0x07) | // source DIV 128 Bits 0-2
@@ -730,14 +773,14 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		}
 		const dest = destN - 1
 
-		if ((this.config.max_levels > 16 || dest > 1023) && this.hasCommand(cmds.extendedInterrogate)) {
+		if ((this.effectiveLevels > 16 || dest > 1023) && this.hasCommand(cmds.extendedInterrogate)) {
 			// check all levels
-			for (let i = 0; i < this.config.max_levels; i++) {
+			for (let i = 0; i < this.effectiveLevels; i++) {
 				await this.sendMessage([
 					// Extended commands
 					cmds.extendedInterrogate,
 					// Matrix
-					this.config.matrix - 1,
+					this.effectiveMatrix - 1,
 					// Level
 					i,
 					// Dest DIV 256
@@ -747,7 +790,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 				])
 			}
 		} else {
-			if (this.config.max_levels > 16 || dest > 1023) {
+			if (this.effectiveLevels > 16 || dest > 1023) {
 				this.log(
 					'error',
 					'Doing a crosspoint interrogate with a source, destination or level value outside of the normal command range, but extended support is not supported by the device, cannot do crosspoint interrogate.',
@@ -756,12 +799,12 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 			}
 
 			// check all levels
-			for (let i = 0; i <= this.config.max_levels - 1; i++) {
+			for (let i = 0; i <= this.protocolLevels - 1; i++) {
 				await this.sendMessage([
 					// Standard commands
 					cmds.crosspointInterrogate,
 					// Matrix and Level
-					((this.config.matrix - 1) << 4) | (i & 0x0f),
+					((this.protocolMatrix - 1) << 4) | (i & 0x0f),
 					// Multiplier dest > 128
 					((dest >> 7) & 0x07) << 4, // dest DIV 128 Bits 4-6
 					dest & 0x7f, // Destination MOD 128
@@ -980,8 +1023,8 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 			// byte1 = matrix (in bits 4-7), level (in bits 3-0) per SW-P-08 spec
 			if (options.hasMatrix) {
 				matrix = (data[idx] & 0xf0) >> 4
-				if (matrix !== this.config.matrix - 1) {
-					this.log('debug', `Matrix number ${matrix} does not match ${this.config.matrix - 1}`)
+				if (matrix !== this.protocolMatrix - 1) {
+					this.log('debug', `Matrix number ${matrix} does not match ${this.protocolMatrix - 1}`)
 					return
 				}
 			}
@@ -995,8 +1038,8 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 			let idx = 1
 			if (options.hasMatrix) {
 				matrix = data[idx++]
-				if (matrix !== this.config.matrix_ext - 1) {
-					this.log('debug', `Matrix number ${matrix} does not match ${this.config.matrix_ext - 1}`)
+				if (matrix !== this.effectiveMatrix - 1) {
+					this.log('debug', `Matrix number ${matrix} does not match ${this.effectiveMatrix - 1}`)
 					return
 				}
 			}
@@ -1112,19 +1155,23 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 			// extended commands (only gets source names for level 0)
 			cmdGetSources.push(
 				cmds.extendedGetSourceNames,
-				this.config.matrix_ext - 1, // matrix
+				this.effectiveMatrix - 1, // matrix
 				0, // level
 				Number.parseInt(this.config.name_chars), // name characters
 			)
 			cmdGetDestinations.push(
 				cmds.extendedGetDestNames,
-				this.config.matrix_ext - 1, // matrix
+				this.effectiveMatrix - 1, // matrix
 				Number.parseInt(this.config.name_chars), // name characters
 			)
 		} else {
 			// standard commands
-			cmdGetSources.push(cmds.getSourceNames, (this.config.matrix - 1) << 4, Number.parseInt(this.config.name_chars))
-			cmdGetDestinations.push(cmds.getDestNames, (this.config.matrix - 1) << 4, Number.parseInt(this.config.name_chars))
+			cmdGetSources.push(cmds.getSourceNames, (this.protocolMatrix - 1) << 4, Number.parseInt(this.config.name_chars))
+			cmdGetDestinations.push(
+				cmds.getDestNames,
+				(this.protocolMatrix - 1) << 4,
+				Number.parseInt(this.config.name_chars),
+			)
 		}
 
 		// get source names
@@ -1145,7 +1192,12 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		this.selected_dest = 0
 		this.selected_source = 0
 
-		const currentLevels = (this.config.extended_support ? this.config.max_levels_ext : this.config.max_levels) || 3
+		if (!this.effectiveLevels || this.effectiveLevels < 1) {
+			this.log('error', `Invalid levels configuration: ${this.effectiveLevels} aborting setupVariables`)
+			return
+		}
+
+		const currentLevels = this.effectiveLevels
 
 		this.levels = []
 		this.selected_level = []
@@ -1205,7 +1257,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 			name: 'Selected destination',
 		}
 
-		for (let i = 1; i <= this.config.max_levels; i++) {
+		for (let i = 1; i <= this.effectiveLevels; i++) {
 			coreVariables[`Sel_Dest_Source_Level_${i}`] = {
 				name: `Selected destination source for level ${i}`,
 			}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1175,6 +1175,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		this.log('debug', `Processing Levels Selection: ${selection}`)
 
 		for (const level of selection) {
+			if (level < 1 || level > this.selected_level.length) break
 			if (state === 'toggle') {
 				this.selected_level[level - 1].enabled = !this.selected_level[level - 1].enabled
 			} else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,7 +260,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 	}
 
 	private async readTally(): Promise<void> {
-		if (this.config.extended_support) {
+		if (this.config.extended_support || this.hasCommandSafe(cmds.extendedCrosspointTallyDump)) {
 			for (let i = 0; i < this.effectiveLevels; i++) {
 				await this.sendMessage([cmds.extendedCrosspointTallyDump, this.effectiveMatrix - 1, i])
 			}
@@ -282,6 +282,16 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 			return true
 		}
 
+		return this.commands.includes(cmdCode)
+	}
+
+	/**
+	 * True if the cmdCode is reported as supported. Fallsback to false
+	 * @param {number } cmdCode
+	 * @returns { boolean }
+	 */
+
+	private hasCommandSafe(cmdCode: number): boolean {
 		return this.commands.includes(cmdCode)
 	}
 
@@ -767,7 +777,10 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		const dest = destN - 1
 		const level = levelN - 1
 
-		if ((source > 1023 || dest > 1023 || level > 15) && this.hasCommand(cmds.extendedCrosspointConnect)) {
+		if (
+			((source > 1023 || dest > 1023 || level > 15) && this.hasCommand(cmds.extendedCrosspointConnect)) ||
+			this.hasCommandSafe(cmds.extendedCrosspointConnect)
+		) {
 			if (this.config.extended_support === false) {
 				this.log(
 					'warn',
@@ -824,7 +837,10 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		}
 		const dest = destN - 1
 
-		if ((this.effectiveLevels > 16 || dest > 1023) && this.hasCommand(cmds.extendedInterrogate)) {
+		if (
+			((this.effectiveLevels > 16 || dest > 1023) && this.hasCommand(cmds.extendedInterrogate)) ||
+			this.hasCommandSafe(cmds.extendedInterrogate)
+		) {
 			// check all levels
 			for (let i = 0; i < this.effectiveLevels; i++) {
 				await this.sendMessage([
@@ -1198,8 +1214,9 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		this.setVariableValuesCached({ Sources: 0, Destinations: 0 })
 
 		if (
-			this.config.extended_support === true &&
-			(this.hasCommand(cmds.extendedGetSourceNames) || this.hasCommand(cmds.extendedGetDestNames))
+			(this.config.extended_support === true &&
+				(this.hasCommand(cmds.extendedGetSourceNames) || this.hasCommand(cmds.extendedGetDestNames))) ||
+			(this.hasCommandSafe(cmds.extendedGetSourceNames) && this.hasCommandSafe(cmds.extendedGetDestNames))
 		) {
 			// extended commands (only gets source names for level 0)
 			cmdGetSources.push(

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 
 	public dest_names: Map<number, DropdownChoice> = new Map()
 	public source_names: Map<number, DropdownChoice> = new Map()
-	public levels: DropdownChoice[] = []
+	public levels: DropdownChoice<number>[] = []
 
 	public selected_source: number = 0
 	public selected_dest: number = 0

--- a/src/index.ts
+++ b/src/index.ts
@@ -233,7 +233,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		return output
 	}
 
-	private async waitForAck(retryCb: () => Promise<void>, retries = 1): Promise<void> {
+	private async waitForAck(): Promise<void> {
 		return new Promise((resolve, reject) => {
 			// eslint-disable-next-line prefer-const
 			let entry: AckCallback
@@ -241,7 +241,6 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 			const timeout = setTimeout(() => {
 				const index = this.ackCallbacks.indexOf(entry)
 				if (index !== -1) this.ackCallbacks.splice(index, 1)
-
 				this.consecutiveAckFailures++
 				reject(new Error('ACK timeout'))
 			}, 1000)
@@ -249,25 +248,11 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 			entry = {
 				resolve: () => {
 					clearTimeout(timeout)
-					this.lastAckAt = Date.now()
-					this.consecutiveAckFailures = 0
 					resolve()
 				},
 				reject: () => {
 					clearTimeout(timeout)
-					this.consecutiveAckFailures++
-
-					if (retries > 0 && this.socket?.isConnected) {
-						this.queue
-							.add(async () => {
-								await retryCb()
-								await this.waitForAck(retryCb, retries - 1)
-							})
-							.then(resolve)
-							.catch(reject)
-					} else {
-						reject(new Error('ACK failed after retries'))
-					}
+					reject(new Error('NAK received'))
 				},
 			}
 
@@ -367,16 +352,27 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		this.log('debug', `Sending >> ${packetBuffer.toString('hex')}`)
 
 		await this.queue.add(async () => {
-			if (this.socket?.isConnected) {
-				await this.socket.sendAsync(packetBuffer)
-
-				await this.waitForAck(async () => {
-					// Retry sending the command if it fails
-					this.log('warn', `Retrying to send message: ${packetBuffer.toString('hex')}`)
-					await this.socket?.sendAsync(packetBuffer).catch(() => {})
-				})
-			} else {
+			if (!this.socket?.isConnected) {
 				this.log('warn', 'Socket not connected')
+				return
+			}
+
+			const maxAttempts = 2
+			for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+				await this.socket.sendAsync(packetBuffer)
+				try {
+					await this.waitForAck()
+					this.lastAckAt = Date.now()
+					this.consecutiveAckFailures = 0
+					return
+				} catch (_e) {
+					this.consecutiveAckFailures++
+					if (attempt < maxAttempts && this.socket?.isConnected) {
+						this.log('warn', `Attempt ${attempt} failed, retrying: ${packetBuffer.toString('hex')}`)
+					} else {
+						this.log('warn', `All attempts failed: ${packetBuffer.toString('hex')}`)
+					}
+				}
 			}
 		})
 	}
@@ -889,7 +885,6 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 					this.consecutiveAckFailures = 0
 					this.ackCallbacks.shift()?.resolve()
 				} else {
-					this.consecutiveAckFailures++
 					this.ackCallbacks.shift()?.reject()
 				}
 			}

--- a/src/index.ts
+++ b/src/index.ts
@@ -757,7 +757,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 			return
 		}
 
-		if (Number.isNaN(levelN) || levelN < 0 || levelN > 255) {
+		if (Number.isNaN(levelN) || levelN < 0 || levelN > 256) {
 			this.log('warn', `Unable to route level ${levelN}`)
 			return
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1196,7 +1196,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 			name: 'Number of source names returned by router',
 		}
 		coreVariables['Destinations'] = {
-			name: 'Number of source names returned by router',
+			name: 'Number of destination names returned by router',
 		}
 		coreVariables['Source'] = {
 			name: 'Selected source',

--- a/src/index.ts
+++ b/src/index.ts
@@ -327,6 +327,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 			this.socket.on('end', () => {
 				this.stopKeepAliveTimer()
 				this.log('warn', `Connection to ${this.config.host} ended`)
+				this.ackCallbacks = []
 			})
 
 			this.socket.on('connect', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,10 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 	public selected_dest: number = 0
 	public selected_level: Level[] = []
 
+	private lastAckAt = 0
+	private consecutiveAckFailures = 0
+	private inFlight = 0
+
 	private debouncedUpdate = _.debounce(
 		async () => {
 			this.updateVariableDefinitions()
@@ -184,6 +188,19 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		return this.effectiveMatrix
 	}
 
+	private get isConnectionUnhealthy(): boolean {
+		const now = Date.now()
+
+		// Only care about ACK timing if we are actually expecting one
+		const waitingForAck = this.inFlight > 0
+
+		const noRecentAckWhileBusy = waitingForAck && this.lastAckAt !== 0 && now - this.lastAckAt > 3000
+
+		const tooManyFailures = this.consecutiveAckFailures >= 3
+		if (tooManyFailures) this.log('warn', `#{this.consecutiveAckFailures} consecutive ACK failures`)
+
+		return noRecentAckWhileBusy || tooManyFailures
+	}
 
 	// tcp.js functions
 
@@ -218,27 +235,45 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		return output
 	}
 
-	private addAckCallback(retryCb: () => void): void {
-		this.ackCallbacks.push({
-			resolve: () => {
-				//this.log('debug', 'ACK received')
-			},
-			reject: () => {
-				this.log('warn', 'ACK not received, resending')
-				// Retry once
-				if (this.socket?.isConnected) {
-					// Retry sending the command
-					retryCb()
-					this.ackCallbacks.push({
-						resolve: () => {
-							this.log('debug', 'ACK received on second try')
-						},
-						reject: () => {
-							this.log('warn', 'ACK not received on second try')
-						},
-					})
-				}
-			},
+	private async waitForAck(retryCb: () => Promise<void>, retries = 1): Promise<void> {
+		return new Promise((resolve, reject) => {
+			// eslint-disable-next-line prefer-const
+			let entry: AckCallback
+
+			const timeout = setTimeout(() => {
+				const index = this.ackCallbacks.indexOf(entry)
+				if (index !== -1) this.ackCallbacks.splice(index, 1)
+
+				this.consecutiveAckFailures++
+				reject(new Error('ACK timeout'))
+			}, 1000)
+
+			entry = {
+				resolve: () => {
+					clearTimeout(timeout)
+					this.lastAckAt = Date.now()
+					this.consecutiveAckFailures = 0
+					resolve()
+				},
+				reject: () => {
+					clearTimeout(timeout)
+					this.consecutiveAckFailures++
+
+					if (retries > 0 && this.socket?.isConnected) {
+						this.queue
+							.add(async () => {
+								await retryCb()
+								await this.waitForAck(retryCb, retries - 1)
+							})
+							.then(resolve)
+							.catch(reject)
+					} else {
+						reject(new Error('ACK failed after retries'))
+					}
+				},
+			}
+
+			this.ackCallbacks.push(entry)
 		})
 	}
 
@@ -323,13 +358,18 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 
 		await this.queue.add(async () => {
 			if (this.socket?.isConnected) {
-				await this.socket.sendAsync(packetBuffer)
+				this.inFlight++
+				try {
+					await this.socket.sendAsync(packetBuffer)
 
-				this.addAckCallback(() => {
-					// Retry sending the command if it fails
-					this.log('warn', `Retrying to send message: ${packetBuffer.toString('hex')}`)
-					this.socket?.sendAsync(packetBuffer).catch(() => {})
-				})
+					await this.waitForAck(async () => {
+						// Retry sending the command if it fails
+						this.log('warn', `Retrying to send message: ${packetBuffer.toString('hex')}`)
+						await this.socket?.sendAsync(packetBuffer).catch(() => {})
+					})
+				} finally {
+					this.inFlight--
+				}
 			} else {
 				this.log('warn', 'Socket not connected')
 			}
@@ -398,9 +438,9 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 					// parseData will return the number of bytes consumed, and will retry until no more data is present
 
 					try {
-					const bytesConsumed = this.decode(receivebuffer)
+						const bytesConsumed = this.decode(receivebuffer)
 						if (bytesConsumed === 0) break
-					receivebuffer = receivebuffer.subarray(bytesConsumed)
+						receivebuffer = receivebuffer.subarray(bytesConsumed)
 					} catch (e) {
 						this.log('error', `Failed to decode packet: ${e instanceof Error ? e.message : String(e)}`)
 						receivebuffer = receivebuffer.subarray(1) // skip bad byte and keep trying
@@ -431,8 +471,13 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 
 	private async keepAlive(): Promise<void> {
 		if (this.socket?.isConnected) {
-			// Send dummy message if the queue is empty
-			if (this.queue.size === 0) {
+			if (this.isConnectionUnhealthy) {
+				this.log('warn', 'Connection looks unhealthy, sending probe')
+				await this.getCrosspoints(1)
+				return
+			}
+			// Query crosspoint as proxy for proper keep alive message if the queue is empty
+			if (this.queue.size === 0 && this.queue.pending === 0) {
 				await this.getCrosspoints(1) // Query a crosspoint since there isnt a specificed keep alive message
 			}
 		}
@@ -715,7 +760,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		const dest = destN - 1
 		const level = levelN - 1
 
-		if ((source > 1023 || dest > 1023 || levelN > 15) && this.hasCommand(cmds.extendedCrosspointConnect)) {
+		if ((source > 1023 || dest > 1023 || level > 15) && this.hasCommand(cmds.extendedCrosspointConnect)) {
 			if (this.config.extended_support === false) {
 				this.log(
 					'warn',
@@ -738,7 +783,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 			// Source MOD 256
 			cmd.push(source & 0xff)
 		} else {
-			if (source > 1023 || dest > 1023 || levelN > 15) {
+			if (source > 1023 || dest > 1023 || level > 15) {
 				this.log(
 					'error',
 					'Doing a crosspoint connect with a source, destination or level value outside of the normal command range, but extended support is not supported by the device, cannot do crosspoint.',
@@ -834,8 +879,11 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 				this.log('warn', 'Got unexpected ACK/NAK')
 			} else {
 				if (data[1] === ACK) {
+					this.lastAckAt = Date.now()
+					this.consecutiveAckFailures = 0
 					this.ackCallbacks.shift()?.resolve()
 				} else {
+					this.consecutiveAckFailures++
 					this.ackCallbacks.shift()?.reject()
 				}
 			}
@@ -1289,11 +1337,13 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		}
 
 		// Only update if there are changes to the variable definitions
-		let changes = false
-		for (const [key, value] of Object.entries(coreVariables)) {
-			if (!_.isEqual(this.lastVariableDefinitions.get(key), value)) {
-				this.lastVariableDefinitions.set(key, value)
-				changes = true
+		let changes = this.lastVariableDefinitions.size !== Object.keys(coreVariables).length
+		if (!changes) {
+			for (const [key, value] of Object.entries(coreVariables)) {
+				if (!_.isEqual(this.lastVariableDefinitions.get(key), value)) {
+					changes = true
+					break
+				}
 			}
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,6 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 
 	private lastAckAt = 0
 	private consecutiveAckFailures = 0
-	private inFlight = 0
 
 	private debouncedUpdate = _.debounce(
 		async () => {
@@ -191,15 +190,18 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 	private get isConnectionUnhealthy(): boolean {
 		const now = Date.now()
 
-		// Only care about ACK timing if we are actually expecting one
-		const waitingForAck = this.inFlight > 0
+		// queue.pending = actively running tasks (0 or 1 with concurrency:1)
+		// queue.size = waiting to run
+		const waitingForAck = this.queue.pending > 0
 
-		const noRecentAckWhileBusy = waitingForAck && this.lastAckAt !== 0 && now - this.lastAckAt > 3000
+		const stalledWhileBusy = waitingForAck && now - this.lastAckAt > 3000
 
 		const tooManyFailures = this.consecutiveAckFailures >= 3
-		if (tooManyFailures) this.log('warn', `${this.consecutiveAckFailures} consecutive ACK failures`)
+		if (tooManyFailures) {
+			this.log('warn', `${this.consecutiveAckFailures} consecutive ACK failures`)
+		}
 
-		return noRecentAckWhileBusy || tooManyFailures
+		return stalledWhileBusy || tooManyFailures
 	}
 
 	// tcp.js functions
@@ -366,18 +368,13 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 
 		await this.queue.add(async () => {
 			if (this.socket?.isConnected) {
-				this.inFlight++
-				try {
-					await this.socket.sendAsync(packetBuffer)
+				await this.socket.sendAsync(packetBuffer)
 
-					await this.waitForAck(async () => {
-						// Retry sending the command if it fails
-						this.log('warn', `Retrying to send message: ${packetBuffer.toString('hex')}`)
-						await this.socket?.sendAsync(packetBuffer).catch(() => {})
-					})
-				} finally {
-					this.inFlight--
-				}
+				await this.waitForAck(async () => {
+					// Retry sending the command if it fails
+					this.log('warn', `Retrying to send message: ${packetBuffer.toString('hex')}`)
+					await this.socket?.sendAsync(packetBuffer).catch(() => {})
+				})
 			} else {
 				this.log('warn', 'Socket not connected')
 			}
@@ -417,6 +414,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 
 			this.socket.on('connect', () => {
 				this.log('info', `Connected to ${this.config.host}:${this.config.port}`)
+				this.lastAckAt = Date.now() // ← prevents false unhealthy on first message
 				this.ackCallbacks = []
 				this.commands = []
 				this.routeMap = new Map()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1176,7 +1176,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		this.log('debug', `Processing Levels Selection: ${selection}`)
 
 		for (const level of selection) {
-			if (level < 1 || level > this.selected_level.length) break
+			if (level < 1 || level > this.selected_level.length) continue
 			if (state === 'toggle') {
 				this.selected_level[level - 1].enabled = !this.selected_level[level - 1].enabled
 			} else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,16 +206,12 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 
 	private async sendNak(): Promise<void> {
 		this.log('debug', 'Sending NAK')
-		await this.queue.add(async () => {
-			if (this.socket?.isConnected) await this.socket.sendAsync(Buffer.from([DLE, NAK]))
-		})
+		await this.sendRaw(Buffer.from([DLE, NAK]))
 	}
 
 	private async sendAck(): Promise<void> {
 		//this.log('debug', 'Sending ACK')
-		await this.queue.add(async () => {
-			if (this.socket?.isConnected) await this.socket.sendAsync(Buffer.from([DLE, ACK]))
-		})
+		await this.sendRaw(Buffer.from([DLE, ACK]))
 	}
 
 	/**
@@ -295,6 +291,18 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		}
 
 		return this.commands.includes(cmdCode)
+	}
+
+	/**
+	 * Encapsulate a message and send it to the router bypassing the message queue (for ACK / NAK)
+	 * @param {Buffer} message
+	 * @returns { Promise<boolean> }
+	 */
+
+	private async sendRaw(message: Buffer): Promise<void> {
+		if (this.socket?.isConnected) {
+			await this.socket.sendAsync(message)
+		}
 	}
 
 	/**

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,6 +271,12 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		}
 	}
 
+	/**
+	 * True if the cmdCode is reported as supported. Fallsback to true when the supported commands array is empty or not using supported command on connect
+	 * @param {number } cmdCode
+	 * @returns { boolean }
+	 */
+
 	private hasCommand(cmdCode: number): boolean {
 		if (!this.config.supported_commands_on_connect || this.commands.length === 0) {
 			return true

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,7 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 		const noRecentAckWhileBusy = waitingForAck && this.lastAckAt !== 0 && now - this.lastAckAt > 3000
 
 		const tooManyFailures = this.consecutiveAckFailures >= 3
-		if (tooManyFailures) this.log('warn', `#{this.consecutiveAckFailures} consecutive ACK failures`)
+		if (tooManyFailures) this.log('warn', `${this.consecutiveAckFailures} consecutive ACK failures`)
 
 		return noRecentAckWhileBusy || tooManyFailures
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -773,7 +773,6 @@ export default class SW_P_08 extends InstanceBase<SWP08Types> implements Instanc
 					'warn',
 					'Doing a crosspoint connect with a value outside of the normal command range, but extended support is not enabled, using extended command anyway',
 				)
-				return
 			}
 			// Extended command required
 			cmd.push(cmds.extendedCrosspointConnect)

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,105 +401,105 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.59.1":
-  version: 8.59.1
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.59.1"
+"@typescript-eslint/eslint-plugin@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.59.2"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.12.2"
-    "@typescript-eslint/scope-manager": "npm:8.59.1"
-    "@typescript-eslint/type-utils": "npm:8.59.1"
-    "@typescript-eslint/utils": "npm:8.59.1"
-    "@typescript-eslint/visitor-keys": "npm:8.59.1"
+    "@typescript-eslint/scope-manager": "npm:8.59.2"
+    "@typescript-eslint/type-utils": "npm:8.59.2"
+    "@typescript-eslint/utils": "npm:8.59.2"
+    "@typescript-eslint/visitor-keys": "npm:8.59.2"
     ignore: "npm:^7.0.5"
     natural-compare: "npm:^1.4.0"
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
-    "@typescript-eslint/parser": ^8.59.1
+    "@typescript-eslint/parser": ^8.59.2
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/6dedd272d1aac960df74ab81e38bb4b398ac11b52118c69493a3aeecd15984c83bd4cae89df2e8362fbc2213f0a6d68c00d71dd53868fa1b5e1011290d4ea7b6
+  checksum: 10c0/c4c2a67d0ae47ab27e47c46a4cd59eb9941592595d3440cd4dcbccc1983a08c5c9bd276304797964fa2c9276be4cd60077f3087efc6a5370d5b8869720759bc8
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.59.1":
-  version: 8.59.1
-  resolution: "@typescript-eslint/parser@npm:8.59.1"
+"@typescript-eslint/parser@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/parser@npm:8.59.2"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.59.1"
-    "@typescript-eslint/types": "npm:8.59.1"
-    "@typescript-eslint/typescript-estree": "npm:8.59.1"
-    "@typescript-eslint/visitor-keys": "npm:8.59.1"
+    "@typescript-eslint/scope-manager": "npm:8.59.2"
+    "@typescript-eslint/types": "npm:8.59.2"
+    "@typescript-eslint/typescript-estree": "npm:8.59.2"
+    "@typescript-eslint/visitor-keys": "npm:8.59.2"
     debug: "npm:^4.4.3"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/a20271b96e35fa5a8deea11ec40b30f7987daa5c3402e6e763e474517a25af20749a620490af159c2a65048065dea8a6d5fa3527ccc7a3716c2cd648a05ebc55
+  checksum: 10c0/baf8da8ad233908f00bdfe5835c1e03fd7c9256f675a27b0d10d40d0245c158efc847dee1331c61992fbb152d55bfda3111795f8422e9d341f09ec9729364800
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.59.1":
-  version: 8.59.1
-  resolution: "@typescript-eslint/project-service@npm:8.59.1"
+"@typescript-eslint/project-service@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/project-service@npm:8.59.2"
   dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.59.1"
-    "@typescript-eslint/types": "npm:^8.59.1"
+    "@typescript-eslint/tsconfig-utils": "npm:^8.59.2"
+    "@typescript-eslint/types": "npm:^8.59.2"
     debug: "npm:^4.4.3"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/487e60e9696fbae11070fd0591a009c94b932af2a92d37a1a9d9f9eac5bbc2f56fef83f3d4e72349dfdaadf95473bb5fb7332eb13f9296b87b3f14e842f42747
+  checksum: 10c0/0228f01c61e5ef9022b06510f79f97e37daafd165c592927b640e3587d5cec65a8394a541e1fd21bf65df9f6f1948523569966c9e2181d9cfe911240969cebdb
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.59.1":
-  version: 8.59.1
-  resolution: "@typescript-eslint/scope-manager@npm:8.59.1"
+"@typescript-eslint/scope-manager@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/scope-manager@npm:8.59.2"
   dependencies:
-    "@typescript-eslint/types": "npm:8.59.1"
-    "@typescript-eslint/visitor-keys": "npm:8.59.1"
-  checksum: 10c0/05c19039bde67691ad7a558ac61260639593ab0ffd8b73903b0f23c770aa3d79868bc8c1a11cdd5b0c8226e5dcef9ab1d679db46b5c5fe019541216170451614
+    "@typescript-eslint/types": "npm:8.59.2"
+    "@typescript-eslint/visitor-keys": "npm:8.59.2"
+  checksum: 10c0/eec819a96442e98879a66d908a9a388502dc4398005af360dd177907f021ee12e4f2967413b123c4ad4567e7f294b177cf6ee559eed2e86d38ab1af3ed5588a5
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:8.59.1, @typescript-eslint/tsconfig-utils@npm:^8.59.1":
-  version: 8.59.1
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.59.1"
+"@typescript-eslint/tsconfig-utils@npm:8.59.2, @typescript-eslint/tsconfig-utils@npm:^8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.59.2"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/a3d123edbc39e7bfa3f58f722fe755787e71771d97b03ed80ea0706dcf3f25895e217e61b38049db1b05f246a26c6afb4e4a518bad21e7d1e71bb8dc136084ce
+  checksum: 10c0/ca7f386cdc9fa4b8c5de3622e2019b9729b8f5682292e01cc42b7cee4a7fc13005642b9dde733b429ad4e6f8600608930d9c33711d8c20c4f9d0af6520ba78d8
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.59.1":
-  version: 8.59.1
-  resolution: "@typescript-eslint/type-utils@npm:8.59.1"
+"@typescript-eslint/type-utils@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/type-utils@npm:8.59.2"
   dependencies:
-    "@typescript-eslint/types": "npm:8.59.1"
-    "@typescript-eslint/typescript-estree": "npm:8.59.1"
-    "@typescript-eslint/utils": "npm:8.59.1"
+    "@typescript-eslint/types": "npm:8.59.2"
+    "@typescript-eslint/typescript-estree": "npm:8.59.2"
+    "@typescript-eslint/utils": "npm:8.59.2"
     debug: "npm:^4.4.3"
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/c5f0f8e53f85ddf796a45b485937b7d5aef5c884fed412ff945392376166242658e4b431bd9633e1e08d6dba7e83b6125283e4866f5a9b4ae61fec355705122d
+  checksum: 10c0/373ea2b03363e0c16ba75946327f01a130820f8b65976e831294c9e931d22d88d40f67a651a2151f0fcc9c91744019311fddadb608fe63ff6c0a65130417c34e
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.59.1, @typescript-eslint/types@npm:^8.59.1":
-  version: 8.59.1
-  resolution: "@typescript-eslint/types@npm:8.59.1"
-  checksum: 10c0/a0bf98389e8673d4aa1034fdef9bb78f576b3dc6b8f413d4adf07ef6edff4a33fdb916148c3bac2cafdbf282c765eebf253c2a05edf3fda4123b8889921cd518
+"@typescript-eslint/types@npm:8.59.2, @typescript-eslint/types@npm:^8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/types@npm:8.59.2"
+  checksum: 10c0/ee6889a22b237ef426c45f11dc167f7f220007c2a8f77c8b1ab9e57ac32a2b47fad29f53c4230847cbe49bcd30a35fc2f276e01611d0dab9918d7ef72334f423
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.59.1":
-  version: 8.59.1
-  resolution: "@typescript-eslint/typescript-estree@npm:8.59.1"
+"@typescript-eslint/typescript-estree@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/typescript-estree@npm:8.59.2"
   dependencies:
-    "@typescript-eslint/project-service": "npm:8.59.1"
-    "@typescript-eslint/tsconfig-utils": "npm:8.59.1"
-    "@typescript-eslint/types": "npm:8.59.1"
-    "@typescript-eslint/visitor-keys": "npm:8.59.1"
+    "@typescript-eslint/project-service": "npm:8.59.2"
+    "@typescript-eslint/tsconfig-utils": "npm:8.59.2"
+    "@typescript-eslint/types": "npm:8.59.2"
+    "@typescript-eslint/visitor-keys": "npm:8.59.2"
     debug: "npm:^4.4.3"
     minimatch: "npm:^10.2.2"
     semver: "npm:^7.7.3"
@@ -507,32 +507,32 @@ __metadata:
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/80b2624185d303741a710ba90e4fcb4e52320c1fc614f62cce785bfb39dfb9560ea5d325ff590d929c689b7dae7c28a598a26e1862477cc108c4ae4e8fe62c78
+  checksum: 10c0/8bde0e7d184e4e9d98b1ef32b8692b433c8dc5c54439f4a34ae49cf4cb6117435b86d8d891b58a73676fbcf1162717365945053d48139cafb265f775e6c8d2af
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.59.1":
-  version: 8.59.1
-  resolution: "@typescript-eslint/utils@npm:8.59.1"
+"@typescript-eslint/utils@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/utils@npm:8.59.2"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.9.1"
-    "@typescript-eslint/scope-manager": "npm:8.59.1"
-    "@typescript-eslint/types": "npm:8.59.1"
-    "@typescript-eslint/typescript-estree": "npm:8.59.1"
+    "@typescript-eslint/scope-manager": "npm:8.59.2"
+    "@typescript-eslint/types": "npm:8.59.2"
+    "@typescript-eslint/typescript-estree": "npm:8.59.2"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/82a3fdb52d5f54622f8796eaeca508c630e65bfb94423645c1097b377fd56cf43b2999a83f11f42924e0cbb93b22faca6e572ee27cf550795b99e22193a0d41c
+  checksum: 10c0/d972d6f2ade6639088e3d2acf319c82cd981455a282d245dd715c5d77365647240d2cb34be00ab0d3a3c16593fb5050fcd698d399ff8451801825211d653ce64
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.59.1":
-  version: 8.59.1
-  resolution: "@typescript-eslint/visitor-keys@npm:8.59.1"
+"@typescript-eslint/visitor-keys@npm:8.59.2":
+  version: 8.59.2
+  resolution: "@typescript-eslint/visitor-keys@npm:8.59.2"
   dependencies:
-    "@typescript-eslint/types": "npm:8.59.1"
+    "@typescript-eslint/types": "npm:8.59.2"
     eslint-visitor-keys: "npm:^5.0.0"
-  checksum: 10c0/1144426dda53e855698301eae6301ae928785915225e6a775f0b51bf5d67b67e90def7b851e851ce76235cff3e1324132d03c7843a33ce2c4f0eb0764cc2b80a
+  checksum: 10c0/5863ea98ac642d94fd100f0077c5cfcbe168c3e2ac9bd05da7fc9878c32c20b6d4fc6916df44ffe79c538c4f367a083489d70dab07aa09c51e4e7729716d106e
   languageName: node
   linkType: hard
 
@@ -591,7 +591,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^6.2.1":
+"ansi-styles@npm:^6.2.1, ansi-styles@npm:^6.2.3":
   version: 6.2.3
   resolution: "ansi-styles@npm:6.2.3"
   checksum: 10c0/23b8a4ce14e18fb854693b95351e286b771d23d8844057ed2e7d083cd3e708376c3323707ec6a24365f7d7eda3ca00327fe04092e29e551499ec4c8b7bfac868
@@ -671,13 +671,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-truncate@npm:^5.0.0":
-  version: 5.1.1
-  resolution: "cli-truncate@npm:5.1.1"
+"cli-truncate@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "cli-truncate@npm:5.2.0"
   dependencies:
-    slice-ansi: "npm:^7.1.0"
-    string-width: "npm:^8.0.0"
-  checksum: 10c0/3842920829a62f3e041ce39199050c42706c3c9c756a4efc8b86d464e102d1fa031d8b1b9b2e3bb36e1017c763558275472d031bdc884c1eff22a2f20e4f6b0a
+    slice-ansi: "npm:^8.0.0"
+    string-width: "npm:^8.2.0"
+  checksum: 10c0/0d4ec94702ca85b64522ac93633837fb5ea7db17b79b1322a60f6045e6ae2b8cd7bd4c1d19ac7d1f9e10e3bbda1112e172e439b68c02b785ee00da8d6a5c5471
   languageName: node
   linkType: hard
 
@@ -701,20 +701,6 @@ __metadata:
   version: 2.9.3
   resolution: "colord@npm:2.9.3"
   checksum: 10c0/9699e956894d8996b28c686afe8988720785f476f59335c80ce852ded76ab3ebe252703aec53d9bef54f6219aea6b960fb3d9a8300058a1d0c0d4026460cd110
-  languageName: node
-  linkType: hard
-
-"colorette@npm:^2.0.20":
-  version: 2.0.20
-  resolution: "colorette@npm:2.0.20"
-  checksum: 10c0/e94116ff33b0ff56f3b83b9ace895e5bf87c2a7a47b3401b8c3f3226e050d5ef76cf4072fb3325f9dc24d1698f9b730baf4e05eeaf861d74a1883073f4c98a40
-  languageName: node
-  linkType: hard
-
-"commander@npm:^14.0.3":
-  version: 14.0.3
-  resolution: "commander@npm:14.0.3"
-  checksum: 10c0/755652564bbf56ff2ff083313912b326450d3f8d8c85f4b71416539c9a05c3c67dbd206821ca72635bf6b160e2afdefcb458e86b317827d5cb333b69ce7f1a24
   languageName: node
   linkType: hard
 
@@ -1072,7 +1058,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^5.0.1, eventemitter3@npm:^5.0.4":
+"eventemitter3@npm:^5.0.4":
   version: 5.0.4
   resolution: "eventemitter3@npm:5.0.4"
   checksum: 10c0/575b8cac8d709e1473da46f8f15ef311b57ff7609445a7c71af5cd42598583eee6f098fa7a593e30f27e94b8865642baa0689e8fa97c016f742abdb3b1bf6d9a
@@ -1175,13 +1161,13 @@ __metadata:
     "@types/node": "npm:^22.19.17"
     eslint: "npm:^9.39.4"
     husky: "npm:^9.1.7"
-    lint-staged: "npm:^16.4.0"
+    lint-staged: "npm:^17.0.2"
     lodash: "npm:^4.18.1"
     p-queue: "npm:^9.2.0"
     prettier: "npm:^3.8.3"
     rimraf: "npm:^6.1.3"
     typescript: "npm:^6.0.3"
-    typescript-eslint: "npm:^8.59.1"
+    typescript-eslint: "npm:^8.59.2"
   languageName: unknown
   linkType: soft
 
@@ -1303,7 +1289,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-fullwidth-code-point@npm:^5.0.0":
+"is-fullwidth-code-point@npm:^5.0.0, is-fullwidth-code-point@npm:^5.1.0":
   version: 5.1.0
   resolution: "is-fullwidth-code-point@npm:5.1.0"
   dependencies:
@@ -1379,33 +1365,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lint-staged@npm:^16.4.0":
-  version: 16.4.0
-  resolution: "lint-staged@npm:16.4.0"
+"lint-staged@npm:^17.0.2":
+  version: 17.0.2
+  resolution: "lint-staged@npm:17.0.2"
   dependencies:
-    commander: "npm:^14.0.3"
-    listr2: "npm:^9.0.5"
-    picomatch: "npm:^4.0.3"
+    listr2: "npm:^10.2.1"
+    picomatch: "npm:^4.0.4"
     string-argv: "npm:^0.3.2"
-    tinyexec: "npm:^1.0.4"
-    yaml: "npm:^2.8.2"
+    tinyexec: "npm:^1.1.2"
+    yaml: "npm:^2.8.4"
+  dependenciesMeta:
+    yaml:
+      optional: true
   bin:
     lint-staged: bin/lint-staged.js
-  checksum: 10c0/67625a49a2a01368c7df2da7e553567a79c4b261d9faf3436e00fc3a2f9c4bbe7295909012c47b3d9029e269fd7d7469901a5120573527a032f15797aa497c26
+  checksum: 10c0/c1ecf8478988bb586de7023d424d01f8a2a1b0114c1782b7d1da2e0706ebfdf7c9f48cc67407c5e7f7e93b7efe97b8dbb75e264b8ae72f63711a31607b82b1a4
   languageName: node
   linkType: hard
 
-"listr2@npm:^9.0.5":
-  version: 9.0.5
-  resolution: "listr2@npm:9.0.5"
+"listr2@npm:^10.2.1":
+  version: 10.2.1
+  resolution: "listr2@npm:10.2.1"
   dependencies:
-    cli-truncate: "npm:^5.0.0"
-    colorette: "npm:^2.0.20"
-    eventemitter3: "npm:^5.0.1"
+    cli-truncate: "npm:^5.2.0"
+    eventemitter3: "npm:^5.0.4"
     log-update: "npm:^6.1.0"
     rfdc: "npm:^1.4.1"
-    wrap-ansi: "npm:^9.0.0"
-  checksum: 10c0/46448d1ba0addc9d71aeafd05bb8e86ded9641ccad930ac302c2bd2ad71580375604743e18586fcb8f11906edf98e8e17fca75ba0759947bf275d381f68e311d
+    wrap-ansi: "npm:^10.0.0"
+  checksum: 10c0/a381a7aaef2e8625e6e882835ef446d14306c8fa371b56c4499cf23ece86f84922008af11962bfba5411b51589e02d280bea2b820451a2efad89ebf78bbe68a4
   languageName: node
   linkType: hard
 
@@ -1632,7 +1619,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
+"picomatch@npm:^4.0.2, picomatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
@@ -1756,6 +1743,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"slice-ansi@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "slice-ansi@npm:8.0.0"
+  dependencies:
+    ansi-styles: "npm:^6.2.3"
+    is-fullwidth-code-point: "npm:^5.1.0"
+  checksum: 10c0/0ce4aa91febb7cea4a00c2c27bb820fa53b6d2862ce0f80f7120134719f7914fc416b0ed966cf35250a3169e152916392f35917a2d7cad0fcc5d8b841010fa9a
+  languageName: node
+  linkType: hard
+
 "string-argv@npm:^0.3.2":
   version: 0.3.2
   resolution: "string-argv@npm:0.3.2"
@@ -1774,13 +1771,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^8.0.0":
-  version: 8.2.0
-  resolution: "string-width@npm:8.2.0"
+"string-width@npm:^8.2.0":
+  version: 8.2.1
+  resolution: "string-width@npm:8.2.1"
   dependencies:
     get-east-asian-width: "npm:^1.5.0"
     strip-ansi: "npm:^7.1.2"
-  checksum: 10c0/d8915428b43519b0f494da6590dbe4491857d8a12e40250e50fc01fbb616ffd8400a436bbe25712255ee129511fe0414c49d3b6b9627e2bc3a33dcec1d2eda02
+  checksum: 10c0/d467b4eaf4c40a01bb438a2620e77badd2456ffd5131c9973abe4f3acf7c802d5b21f3b6a00a5e33a7fc28ca8f9c103226e01bac61e9f259659c6f46d78e353a
   languageName: node
   linkType: hard
 
@@ -1838,10 +1835,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyexec@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "tinyexec@npm:1.0.4"
-  checksum: 10c0/d4a5bbcf6bdb23527a4b74c4aa566f41432167112fe76f420ec7e3a90a3ecfd3a7d944383e2719fc3987b69400f7b928daf08700d145fb527c2e80ec01e198bd
+"tinyexec@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "tinyexec@npm:1.1.2"
+  checksum: 10c0/9e0ef6c001ce54688cf16833a02f70a339276219ca947b88930b124267de2cffc764ff44e87e7369384b1d75ab63491465412cbbdf06f2437956b9ab66ab4491
   languageName: node
   linkType: hard
 
@@ -1891,18 +1888,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.59.1":
-  version: 8.59.1
-  resolution: "typescript-eslint@npm:8.59.1"
+"typescript-eslint@npm:^8.59.2":
+  version: 8.59.2
+  resolution: "typescript-eslint@npm:8.59.2"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.59.1"
-    "@typescript-eslint/parser": "npm:8.59.1"
-    "@typescript-eslint/typescript-estree": "npm:8.59.1"
-    "@typescript-eslint/utils": "npm:8.59.1"
+    "@typescript-eslint/eslint-plugin": "npm:8.59.2"
+    "@typescript-eslint/parser": "npm:8.59.2"
+    "@typescript-eslint/typescript-estree": "npm:8.59.2"
+    "@typescript-eslint/utils": "npm:8.59.2"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/93f3d66e2a2427a719a19f7bfd5d21c76a6bdcf9cfe82ba14d37f869434893f7d4d62c75671a87a93a3ef13816636d2bfe79b2f145d6cbcda5efbfddd90c1c2d
+  checksum: 10c0/c2736b839fa268da75df0ca8a1b8cfd658a6c6210c676412ed902c7ff8fea716f36a7e135133000a8f72091255f395d7c85783c4d6a9b1be79e8989abde1cd43
   languageName: node
   linkType: hard
 
@@ -1967,6 +1964,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"wrap-ansi@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "wrap-ansi@npm:10.0.0"
+  dependencies:
+    ansi-styles: "npm:^6.2.3"
+    string-width: "npm:^8.2.0"
+    strip-ansi: "npm:^7.1.2"
+  checksum: 10c0/6b163457630fe6d1c72aeed283a7410b2cc7487312df8b0ce96df3fbd64a2a7c948856ea97c25148c848627587c5c7945be474d8e723ab6011bb0756a53a9e89
+  languageName: node
+  linkType: hard
+
 "wrap-ansi@npm:^9.0.0":
   version: 9.0.2
   resolution: "wrap-ansi@npm:9.0.2"
@@ -1985,12 +1993,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.8.2":
-  version: 2.8.2
-  resolution: "yaml@npm:2.8.2"
+"yaml@npm:^2.8.4":
+  version: 2.8.4
+  resolution: "yaml@npm:2.8.4"
   bin:
     yaml: bin.mjs
-  checksum: 10c0/703e4dc1e34b324aa66876d63618dcacb9ed49f7e7fe9b70f1e703645be8d640f68ab84f12b86df8ac960bac37acf5513e115de7c970940617ce0343c8c9cd96
+  checksum: 10c0/0a33a1fa28d4bc79f61a12ec7ef7a2bce0ce5f8e80c6eaecfb4a0c88c08767dd1ede372b6a3bcd70891213b8c9f3169b355c97e77026d3b3459e10d2cccaef1e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -392,114 +392,114 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^22.19.17":
-  version: 22.19.17
-  resolution: "@types/node@npm:22.19.17"
+"@types/node@npm:^22.19.19":
+  version: 22.19.19
+  resolution: "@types/node@npm:22.19.19"
   dependencies:
     undici-types: "npm:~6.21.0"
-  checksum: 10c0/b66c484c0a9f6d88b1ef360b0f487717234ee1a482cb2551ff73d9f3c43a42a777daf4c8a5eee970960728f8fe1f3877d3d8c6ffabcbca74cb401a59db700fa4
+  checksum: 10c0/402e0f088c94cabda3cd721546bd8e4e75e098e0b342f6e03b90ca1e19c28986f9650112c64fcfd09fc8cebc0f8b20291a513153e90489331cf666e1e5503e16
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.59.2":
-  version: 8.59.2
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.59.2"
+"@typescript-eslint/eslint-plugin@npm:8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.59.3"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.12.2"
-    "@typescript-eslint/scope-manager": "npm:8.59.2"
-    "@typescript-eslint/type-utils": "npm:8.59.2"
-    "@typescript-eslint/utils": "npm:8.59.2"
-    "@typescript-eslint/visitor-keys": "npm:8.59.2"
+    "@typescript-eslint/scope-manager": "npm:8.59.3"
+    "@typescript-eslint/type-utils": "npm:8.59.3"
+    "@typescript-eslint/utils": "npm:8.59.3"
+    "@typescript-eslint/visitor-keys": "npm:8.59.3"
     ignore: "npm:^7.0.5"
     natural-compare: "npm:^1.4.0"
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
-    "@typescript-eslint/parser": ^8.59.2
+    "@typescript-eslint/parser": ^8.59.3
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/c4c2a67d0ae47ab27e47c46a4cd59eb9941592595d3440cd4dcbccc1983a08c5c9bd276304797964fa2c9276be4cd60077f3087efc6a5370d5b8869720759bc8
+  checksum: 10c0/c316ba4af95c7408c65279005099386c1547c184929b7027a1041a2450537d5ce7bd9276e0d6774ae384f9e4482e392dc3305686442d64777c448d76f39fd665
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.59.2":
-  version: 8.59.2
-  resolution: "@typescript-eslint/parser@npm:8.59.2"
+"@typescript-eslint/parser@npm:8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/parser@npm:8.59.3"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.59.2"
-    "@typescript-eslint/types": "npm:8.59.2"
-    "@typescript-eslint/typescript-estree": "npm:8.59.2"
-    "@typescript-eslint/visitor-keys": "npm:8.59.2"
+    "@typescript-eslint/scope-manager": "npm:8.59.3"
+    "@typescript-eslint/types": "npm:8.59.3"
+    "@typescript-eslint/typescript-estree": "npm:8.59.3"
+    "@typescript-eslint/visitor-keys": "npm:8.59.3"
     debug: "npm:^4.4.3"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/baf8da8ad233908f00bdfe5835c1e03fd7c9256f675a27b0d10d40d0245c158efc847dee1331c61992fbb152d55bfda3111795f8422e9d341f09ec9729364800
+  checksum: 10c0/a5e16163e6fdeff411272e8fa2e26b48c28aae3003ff2a6b52e7c7727061170afde11261feefba0b578399774a6c9b26e5d58d593e66b25f88a4552e6012d9e2
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.59.2":
-  version: 8.59.2
-  resolution: "@typescript-eslint/project-service@npm:8.59.2"
+"@typescript-eslint/project-service@npm:8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/project-service@npm:8.59.3"
   dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.59.2"
-    "@typescript-eslint/types": "npm:^8.59.2"
+    "@typescript-eslint/tsconfig-utils": "npm:^8.59.3"
+    "@typescript-eslint/types": "npm:^8.59.3"
     debug: "npm:^4.4.3"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/0228f01c61e5ef9022b06510f79f97e37daafd165c592927b640e3587d5cec65a8394a541e1fd21bf65df9f6f1948523569966c9e2181d9cfe911240969cebdb
+  checksum: 10c0/14caf773ce7198e097e7cf1ba65b0dfd0553696b5ffc1842f0f5bbc877450d1aab599dd0209b1bca66e4a03ba176051dfa13e30005b8f0a96453d7a01e8d8ba6
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.59.2":
-  version: 8.59.2
-  resolution: "@typescript-eslint/scope-manager@npm:8.59.2"
+"@typescript-eslint/scope-manager@npm:8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/scope-manager@npm:8.59.3"
   dependencies:
-    "@typescript-eslint/types": "npm:8.59.2"
-    "@typescript-eslint/visitor-keys": "npm:8.59.2"
-  checksum: 10c0/eec819a96442e98879a66d908a9a388502dc4398005af360dd177907f021ee12e4f2967413b123c4ad4567e7f294b177cf6ee559eed2e86d38ab1af3ed5588a5
+    "@typescript-eslint/types": "npm:8.59.3"
+    "@typescript-eslint/visitor-keys": "npm:8.59.3"
+  checksum: 10c0/716c342e3e4963431696f4a68c616e0afdb619a94fabf448d032a9a676d75d39d60926cd6b47ccd712c722f7cf549a2f623f97049017f36e953dd9b7b348e9bd
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:8.59.2, @typescript-eslint/tsconfig-utils@npm:^8.59.2":
-  version: 8.59.2
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.59.2"
+"@typescript-eslint/tsconfig-utils@npm:8.59.3, @typescript-eslint/tsconfig-utils@npm:^8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.59.3"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/ca7f386cdc9fa4b8c5de3622e2019b9729b8f5682292e01cc42b7cee4a7fc13005642b9dde733b429ad4e6f8600608930d9c33711d8c20c4f9d0af6520ba78d8
+  checksum: 10c0/326c07ae30e04734b28830ff74fbc8478f58671f0111a540854064d5a1cd15ed22056453165200ce342de9758e4ce45c827068017701dfb8390ec1c6b3c990ab
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.59.2":
-  version: 8.59.2
-  resolution: "@typescript-eslint/type-utils@npm:8.59.2"
+"@typescript-eslint/type-utils@npm:8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/type-utils@npm:8.59.3"
   dependencies:
-    "@typescript-eslint/types": "npm:8.59.2"
-    "@typescript-eslint/typescript-estree": "npm:8.59.2"
-    "@typescript-eslint/utils": "npm:8.59.2"
+    "@typescript-eslint/types": "npm:8.59.3"
+    "@typescript-eslint/typescript-estree": "npm:8.59.3"
+    "@typescript-eslint/utils": "npm:8.59.3"
     debug: "npm:^4.4.3"
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/373ea2b03363e0c16ba75946327f01a130820f8b65976e831294c9e931d22d88d40f67a651a2151f0fcc9c91744019311fddadb608fe63ff6c0a65130417c34e
+  checksum: 10c0/ff0dfb47fafe6046c0cf08b1790db41dc8e0b93dfa5bdd69f78d1cb58880b85bfb7930079c417664498a203b894381b228141efc27f427d1969c6aecc25e63b9
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.59.2, @typescript-eslint/types@npm:^8.59.2":
-  version: 8.59.2
-  resolution: "@typescript-eslint/types@npm:8.59.2"
-  checksum: 10c0/ee6889a22b237ef426c45f11dc167f7f220007c2a8f77c8b1ab9e57ac32a2b47fad29f53c4230847cbe49bcd30a35fc2f276e01611d0dab9918d7ef72334f423
+"@typescript-eslint/types@npm:8.59.3, @typescript-eslint/types@npm:^8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/types@npm:8.59.3"
+  checksum: 10c0/3f7836ce108c3098935180221abce6d9dbf3583216b895525b0a1fc8d0207ebe1ba9e571dbb45eddacd14ef99563350b9b51df3091258211f8d267f02b9a80c1
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.59.2":
-  version: 8.59.2
-  resolution: "@typescript-eslint/typescript-estree@npm:8.59.2"
+"@typescript-eslint/typescript-estree@npm:8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/typescript-estree@npm:8.59.3"
   dependencies:
-    "@typescript-eslint/project-service": "npm:8.59.2"
-    "@typescript-eslint/tsconfig-utils": "npm:8.59.2"
-    "@typescript-eslint/types": "npm:8.59.2"
-    "@typescript-eslint/visitor-keys": "npm:8.59.2"
+    "@typescript-eslint/project-service": "npm:8.59.3"
+    "@typescript-eslint/tsconfig-utils": "npm:8.59.3"
+    "@typescript-eslint/types": "npm:8.59.3"
+    "@typescript-eslint/visitor-keys": "npm:8.59.3"
     debug: "npm:^4.4.3"
     minimatch: "npm:^10.2.2"
     semver: "npm:^7.7.3"
@@ -507,32 +507,32 @@ __metadata:
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/8bde0e7d184e4e9d98b1ef32b8692b433c8dc5c54439f4a34ae49cf4cb6117435b86d8d891b58a73676fbcf1162717365945053d48139cafb265f775e6c8d2af
+  checksum: 10c0/d23d4efa17ebfceaca741e0656f4cc69f6429fad0bba87fa79cf08b6b67e487282241fd4211ae69d1b9eae1e5746db849e2e29518a385ee981a55f297db58906
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.59.2":
-  version: 8.59.2
-  resolution: "@typescript-eslint/utils@npm:8.59.2"
+"@typescript-eslint/utils@npm:8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/utils@npm:8.59.3"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.9.1"
-    "@typescript-eslint/scope-manager": "npm:8.59.2"
-    "@typescript-eslint/types": "npm:8.59.2"
-    "@typescript-eslint/typescript-estree": "npm:8.59.2"
+    "@typescript-eslint/scope-manager": "npm:8.59.3"
+    "@typescript-eslint/types": "npm:8.59.3"
+    "@typescript-eslint/typescript-estree": "npm:8.59.3"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/d972d6f2ade6639088e3d2acf319c82cd981455a282d245dd715c5d77365647240d2cb34be00ab0d3a3c16593fb5050fcd698d399ff8451801825211d653ce64
+  checksum: 10c0/a8299781be03e43f9a0f4006e607cfaa1094e2d5b1a208e7f2b994841884f08b557ce51d97d128b892b335a99b1bffa151eb4c0173aafec5d012783656e222f0
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.59.2":
-  version: 8.59.2
-  resolution: "@typescript-eslint/visitor-keys@npm:8.59.2"
+"@typescript-eslint/visitor-keys@npm:8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/visitor-keys@npm:8.59.3"
   dependencies:
-    "@typescript-eslint/types": "npm:8.59.2"
+    "@typescript-eslint/types": "npm:8.59.3"
     eslint-visitor-keys: "npm:^5.0.0"
-  checksum: 10c0/5863ea98ac642d94fd100f0077c5cfcbe168c3e2ac9bd05da7fc9878c32c20b6d4fc6916df44ffe79c538c4f367a083489d70dab07aa09c51e4e7729716d106e
+  checksum: 10c0/124c1ecece3f1ea954a05b150f8ec89b1c790276baa6e60c542a006cf3e14ce2c6152f95f06740e73609c36c6db0eeba98caba572d19db0befaef8aaba6f9569
   languageName: node
   linkType: hard
 
@@ -1158,16 +1158,16 @@ __metadata:
     "@companion-module/base": "npm:~2.0.4"
     "@companion-module/tools": "npm:^3.0.1"
     "@types/lodash": "npm:^4.17.24"
-    "@types/node": "npm:^22.19.17"
+    "@types/node": "npm:^22.19.19"
     eslint: "npm:^9.39.4"
     husky: "npm:^9.1.7"
-    lint-staged: "npm:^17.0.2"
+    lint-staged: "npm:^17.0.4"
     lodash: "npm:^4.18.1"
     p-queue: "npm:^9.2.0"
     prettier: "npm:^3.8.3"
     rimraf: "npm:^6.1.3"
     typescript: "npm:^6.0.3"
-    typescript-eslint: "npm:^8.59.2"
+    typescript-eslint: "npm:^8.59.3"
   languageName: unknown
   linkType: soft
 
@@ -1365,9 +1365,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lint-staged@npm:^17.0.2":
-  version: 17.0.2
-  resolution: "lint-staged@npm:17.0.2"
+"lint-staged@npm:^17.0.4":
+  version: 17.0.4
+  resolution: "lint-staged@npm:17.0.4"
   dependencies:
     listr2: "npm:^10.2.1"
     picomatch: "npm:^4.0.4"
@@ -1379,7 +1379,7 @@ __metadata:
       optional: true
   bin:
     lint-staged: bin/lint-staged.js
-  checksum: 10c0/c1ecf8478988bb586de7023d424d01f8a2a1b0114c1782b7d1da2e0706ebfdf7c9f48cc67407c5e7f7e93b7efe97b8dbb75e264b8ae72f63711a31607b82b1a4
+  checksum: 10c0/7a1057eb3dff21236e3efcf199241282488d7cb875caabe3d0cd0cc21886b726a8dad65214f9e509b6f722630be6d5b7eace84c016fac35ecb6e2350843c738d
   languageName: node
   linkType: hard
 
@@ -1888,18 +1888,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.59.2":
-  version: 8.59.2
-  resolution: "typescript-eslint@npm:8.59.2"
+"typescript-eslint@npm:^8.59.3":
+  version: 8.59.3
+  resolution: "typescript-eslint@npm:8.59.3"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.59.2"
-    "@typescript-eslint/parser": "npm:8.59.2"
-    "@typescript-eslint/typescript-estree": "npm:8.59.2"
-    "@typescript-eslint/utils": "npm:8.59.2"
+    "@typescript-eslint/eslint-plugin": "npm:8.59.3"
+    "@typescript-eslint/parser": "npm:8.59.3"
+    "@typescript-eslint/typescript-estree": "npm:8.59.3"
+    "@typescript-eslint/utils": "npm:8.59.3"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/c2736b839fa268da75df0ca8a1b8cfd658a6c6210c676412ed902c7ff8fea716f36a7e135133000a8f72091255f395d7c85783c4d6a9b1be79e8989abde1cd43
+  checksum: 10c0/7bd251921d583be5a29565118a5babc068e7c1e893d30a0dbea4215ed20cebcad186b419ba747e001b48339e18c4a2cf6c936e013a77b225692f7f48331839f6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fix: `destination source name` feedback source offset by 1
Improve: Handling of levels and matrix values in extended mode (> 16). 
Fix: `destinations` variable `name` field
Fix: Don't return `SetCrosspoint` early after logging message to say proceeding with extended command despite extended commands not being enabled
Improvement: Prefer extended command set whenever it is supported
Improvement: Don't overwrite config in `configUpdated()`
Improvement: Wait for `ACK` during `sendMessage`, queue processing and consecutive actions will progress after `ACK`
Improvement: Refactor `updateAllCrosspoints()` for better efficieny
Improvement: check for changed size of `coreVariables` during `updateVariableDefinitions()`
Improvement: clear `this.ackCallbacks` on socket `end` event
Improvement: Other minor refactors / typing improvements
