### PR TITLE
fix: make SW-P-08 ACK/NAK strictly request/response (v2.0.13)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generic-swp08",
-	"version": "2.0.12",
+	"version": "2.0.13",
 	"main": "src/index.js",
 	"type": "module",
 	"scripts": {

--- a/src/consts.js
+++ b/src/consts.js
@@ -2,6 +2,7 @@ import { combineRgb } from '@companion-module/base'
 
 export const msgDelay = 5
 export const keepAliveTime = 30000
+export const ackTimeout = 5000 // ms — max wait for ACK/NAK after any send before moving on
 
 export const DLE = 0x10
 export const STX = 0x02

--- a/src/decode.js
+++ b/src/decode.js
@@ -15,15 +15,11 @@ export function decode(data) {
 	}
 
 	if (data[1] === ACK || data[1] === NAK) {
-		// ACK or NAK
-		if (this.ackCallbacks.length === 0) {
-			this.log('warn', 'Got unexpected ACK/NAK')
+		// ACK or NAK for the command we are currently waiting on
+		if (this.pendingAck) {
+			this.pendingAck(data[1] === ACK ? 'ack' : 'nak')
 		} else {
-			if (data[1] === ACK) {
-				this.ackCallbacks.shift().resolve()
-			} else {
-				this.ackCallbacks.shift().reject()
-			}
+			this.log('warn', 'Got unexpected ACK/NAK')
 		}
 		return 2
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ class SW_P_08 extends InstanceBase {
 			...tcp,
 			...util,
 		})
-		this.ackCallbacks = []
+		this.pendingAck = null
 		this.routeMap = new Map()
 		this.lastVariables = new Map()
 		this.lastVariableDefinitions = new Map()
@@ -134,6 +134,8 @@ class SW_P_08 extends InstanceBase {
 	async destroy() {
 		this.log('debug', `destroy. ID: ${this.id}`)
 		this.queue.clear()
+		if (this.pendingAck) this.pendingAck('timeout')
+		this.pendingAck = null
 		this.stopKeepAliveTimer()
 		if (this.socket) {
 			this.socket.destroy()

--- a/src/keepalive.js
+++ b/src/keepalive.js
@@ -1,4 +1,4 @@
-import { keepAliveTime } from './consts.js'
+import { cmds, keepAliveTime } from './consts.js'
 
 export function startKeepAliveTimer() {
 	if (this.keepAliveTimer) {
@@ -19,9 +19,23 @@ export function stopKeepAliveTimer() {
 
 export function keepAlive() {
 	if (this.socket?.isConnected) {
-		// Send dummy message if the queue is empty
+		// Send a keepalive if the queue is empty
 		if (this.queue.size === 0) {
-			this.sendMessage([])
+			// Use a real interrogate (destination 1, level 1) as the keepalive.
+			// A valid query gets exactly one ACK on every device, unlike an empty
+			// message which routers may NAK or ignore.
+			const dest = 0 // destination 1 (0-indexed)
+			const level = 0 // level 1 (0-indexed)
+			if (this.config.extended_support) {
+				this.sendMessage([cmds.extendedInterrogate, this.config.matrix - 1, level, dest >> 8, dest & 0xff])
+			} else {
+				this.sendMessage([
+					cmds.crosspointInterrogate,
+					((this.config.matrix - 1) << 4) | (level & 0x0f),
+					((dest >> 7) & 0x07) << 4, // dest DIV 128
+					dest & 0x7f, // dest MOD 128
+				])
+			}
 		}
 	}
 }

--- a/src/tcp.js
+++ b/src/tcp.js
@@ -1,22 +1,20 @@
 import { InstanceStatus, TCPHelper } from '@companion-module/base'
 import { Buffer } from 'node:buffer'
-import { ACK, NAK, DLE, STX, ETX, cmds } from './consts.js'
+import { ACK, NAK, DLE, STX, ETX, cmds, ackTimeout } from './consts.js'
 
 export function sendNak() {
 	this.log('debug', 'Sending NAK')
+	// Send our link-level ACK/NAK directly, not via the command queue, so they
+	// are never delayed behind a command that is waiting for its ACK.
 	if (this.socket?.isConnected) {
-		this.queue.add(async () => {
-			this.socket.send(Buffer.from([DLE, NAK]))
-		})
+		this.socket.send(Buffer.from([DLE, NAK]))
 	}
 }
 
 export function sendAck() {
 	//this.log('debug', 'Sending ACK')
 	if (this.socket?.isConnected) {
-		this.queue.add(async () => {
-			this.socket.send(Buffer.from([DLE, ACK]))
-		})
+		this.socket.send(Buffer.from([DLE, ACK]))
 	}
 }
 
@@ -37,27 +35,31 @@ function stuffDLE(data) {
 	return output
 }
 
-export function addAckCallback(retryCb) {
-	this.ackCallbacks.push({
-		resolve: () => {
-			//this.log('debug', 'ACK received')
-		},
-		reject: () => {
-			this.log('warn', 'ACK not received, resending')
-			// Retry once
-			if (this.socket?.isConnected) {
-				// Retry sending the command
-				retryCb()
-				this.ackCallbacks.push({
-					resolve: () => {
-						this.log('debug', 'ACK received on second try')
-					},
-					reject: () => {
-						this.log('warn', 'ACK not received on second try')
-					},
-				})
+/**
+ * Wait for the router to ACK or NAK the last command, or time out.
+ * Only one command is ever outstanding, so the reply can only belong to it.
+ * @param {string} messageHex hex of the message we are awaiting a reply for (for logging)
+ * @returns {Promise<'ack'|'nak'|'timeout'>}
+ */
+export function waitForAck(messageHex) {
+	return new Promise((resolve) => {
+		let settled = false
+		const timer = setTimeout(() => {
+			if (settled) return
+			settled = true
+			this.pendingAck = null
+			resolve('timeout')
+		}, ackTimeout)
+		this.pendingAck = (result) => {
+			if (settled) return
+			settled = true
+			clearTimeout(timer)
+			this.pendingAck = null
+			if (result === 'nak') {
+				this.log('debug', `NAK received for message: ${messageHex}`)
 			}
-		},
+			resolve(result)
+		}
 	})
 }
 
@@ -141,19 +143,31 @@ export function sendMessage(message) {
 
 	const packetBuffer = Buffer.from(packet)
 
-	this.log('debug', `Sending >> ${packetBuffer.toString('hex')}`)
-
 	this.queue.add(async () => {
-		if (this.socket?.isConnected) {
-			this.socket.send(packetBuffer)
-
-			this.addAckCallback(() => {
-				// Retry sending the command if it fails
-				this.log('warn', `Retrying to send message: ${packetBuffer.toString('hex')}`)
-				this.socket.send(packetBuffer)
-			})
-		} else {
+		if (!this.socket?.isConnected) {
 			this.log('warn', 'Socket not connected')
+			return
+		}
+
+		const messageHex = packetBuffer.toString('hex')
+		this.log('debug', `Sending >> ${messageHex}`)
+		this.socket.send(packetBuffer)
+
+		// Strict request/response: wait for the router's ACK/NAK before sending
+		// the next message, so a reply can never be attributed to the wrong
+		// command. The wait times out (see ackTimeout) so the queue can never
+		// block forever on a non-responding device.
+		let result = await this.waitForAck(messageHex)
+
+		if (result === 'nak') {
+			// Single retry on NAK, then move on regardless of outcome.
+			this.log('warn', `NAK received, retrying once: ${messageHex}`)
+			this.socket.send(packetBuffer)
+			result = await this.waitForAck(messageHex)
+		}
+
+		if (result !== 'ack') {
+			this.log('warn', `Message not acknowledged (${result}), moving on: ${packetBuffer.toString('hex')}`)
 		}
 	})
 }
@@ -188,7 +202,10 @@ export function init_tcp() {
 
 		this.socket.on('connect', () => {
 			console.log(`Connected to ${this.config.host}:${this.config.port}`)
-			this.ackCallbacks = []
+			// Clean slate so a reconnect can't inherit a stale waiter or queued commands
+			this.queue.clear()
+			if (this.pendingAck) this.pendingAck('timeout')
+			this.pendingAck = null
 			this.commands = []
 			this.routeMap = new Map()
 			this.lastVariables = new Map()


### PR DESCRIPTION
## Problem

A customer controlling a Pro-Bel router reported routes spontaneously flipping back to a previous source minutes after they changed them — with no operator action.

Root cause: the ACK/NAK tracker (`ackCallbacks`) was a **position-based FIFO with no command identity and no timeout**. Any mismatch between commands sent and replies received desynced it permanently. Once desynced, an incoming NAK was matched to the **wrong, stale** pending entry, and the retry path re-sent that entry's captured packet — replaying an old `crosspointConnect`. Logs showed a stale `connect(src122→dst64)` re-transmitted ~16s after it was issued while the operator was on `src127→dst64`.

The dominant desync trigger was the **keepalive**, which sent an empty SW-P-08 message every 30s. The Pro-Bel router NAKs it (5,820 retries in the capture), and different devices handle an empty message differently (ACK / NAK / no reply).

## Fix

Make the protocol strictly request/response so desync is structurally impossible:

- **Wait for ACK/NAK before sending the next message** (a single outstanding command). Replaces the `ackCallbacks` FIFO with a single `pendingAck` waiter — a reply can only ever belong to the current command.
- **Single retry on NAK**, then move on regardless of outcome (no infinite or stale re-sends).
- **5s timeout per send** so the queue can never block forever on a non-responding/disconnected device.
- **Interrogate keepalive** — replace the empty message with a real `crosspointInterrogate` of destination 1 / level 1, which every device answers with exactly one ACK.
- **Send our own link-level ACK/NAK directly** (not via the command queue) so they aren't delayed behind a command that's waiting for its reply.
- **Debug-log the original message a NAK belonged to.**

## Files

- `src/tcp.js` — `waitForAck` helper, synchronous `sendMessage`, direct `sendAck`/`sendNak`, connect-handler reset
- `src/decode.js` — resolve the single `pendingAck` on ACK/NAK
- `src/keepalive.js` — interrogate dest 1 / level 1 instead of empty message
- `src/index.js` — `ackCallbacks` → `pendingAck` (constructor + destroy)
- `src/consts.js` — `ackTimeout = 5000`
- `package.json` — v2.0.13

## Testing

ESLint clean on all changed files; `node --check` passes. The module has no automated test harness, so behavioral verification (keepalive now ACK'd, no stale connect re-sends, retry-once on genuine NAK, ~5s timeout release) needs a live router or log replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)